### PR TITLE
chore: professionalize repository for public profile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,js}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,30 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+    paths: ["problems/**/*.py"]
+  pull_request:
+    paths: ["problems/**/*.py"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check --select=E,F,W,UP,I --ignore=E501
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 node_modules/
+
+__pycache__/
+*.pyc
+*.pyo
+.env
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Important constraints:
 - Preserve the one-file-per-problem structure.
 - Prefer clarity over cleverness unless the problem requires a specific optimization.
 - Do not introduce helper modules for LeetCode solutions.
-- Keep commit messages in the existing style: `problem(<id>): <technique>`.
+- Keep commit messages in Conventional Commits format: `type(scope): description` (e.g. `feat(35): add binary search solution`, `fix(ci): update node version`, `docs: expand README`).
 
 ## Good Task Types For Agents
 
@@ -103,8 +103,9 @@ If behavior changes are non-trivial, explain the expected runtime behavior in Gi
 - Do not commit unrelated files.
 - Do not rewrite history unless explicitly requested.
 - Keep commits focused.
-- For solution commits, use `problem(<id>): <technique>`.
-- For automation/docs commits, use a short imperative message that explains the change.
+- Use Conventional Commits: `type(scope): description`.
+- Solution commits: `feat(<id>): <technique>` (e.g. `feat(35): binary search`).
+- Automation/docs commits: `type: description` (e.g. `fix(ci): update node version`, `docs: expand README`).
 
 When opening a PR, include:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -1,112 +1,87 @@
-# LeetCode Practice Repository
+# LeetCode Practice
 
-This repository is a personal data structures and algorithms practice space.
+[![Daily Problem](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/daily-problem.yml?label=daily%20automation&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/daily-problem.yml)
+[![Issues](https://img.shields.io/github/issues/kovacoj1/leetcode?style=flat-square)](https://github.com/kovacoj1/leetcode/issues)
+[![License](https://img.shields.io/github/license/kovacoj1/leetcode?style=flat-square)](LICENSE)
 
-It has two goals:
+A structured data structures and algorithms practice repository with automated daily problem tracking.
 
-1. keep a growing set of self-contained LeetCode solutions
-2. automate a daily reminder workflow through GitHub Issues
+## What This Is
 
-## Repository Layout
+This repo is a personal DSA practice log. Each problem is a single self-contained Python file, organized by LeetCode problem ID. A GitHub Actions workflow automatically creates a daily issue for the current LeetCode problem, keeping practice consistent over time.
 
-- `problems/`: individual LeetCode solutions in Python
-- `.github/workflows/daily-problem.yml`: scheduled workflow that creates a daily issue
-- `.github/actions/daily-problem/`: custom GitHub Action that fetches the current LeetCode daily problem ID
-- `TODO.md`: study plan and topic roadmap
-- `AGENTS.md`: repo-specific instructions for coding agents
+## Repository Structure
 
-## Problem Files
+```
+problems/<id>.<slug>.py     # one file per solved problem
+.github/workflows/          # daily problem automation
+.github/actions/            # custom action: fetch daily LeetCode ID
+AGENTS.md                   # agent workflow guidance
+TODO.md                     # study plan and topic roadmap
+```
 
-Each LeetCode solution lives in a single file named like this:
+### Problem Files
 
-`problems/<id>.<slug>.py`
+Each solution follows the naming convention `problems/<id>.<slug>.py`:
 
-Examples:
+| File | Problem | Technique |
+|------|---------|-----------|
+| `35.search-insert-position.py` | Search Insert Position | Binary search |
+| `42.trapping-rain-water.py` | Trapping Rain Water | Two pointers |
+| `208.implement-trie-prefix-tree.py` | Implement Trie | Trie |
+| `494.target-sum.py` | Target Sum | Memoized DFS |
 
-- `problems/35.search-insert-position.py`
-- `problems/208.implement-trie-prefix-tree.py`
-- `problems/42.trapping-rain-water.py`
+Solutions are intentionally self-contained — no shared modules, no framework, just a clean `class Solution` implementation per file.
 
-The solution files are intentionally simple:
+## Topics Covered
 
-- no shared helper package
-- no repo-wide problem framework
-- each file should stay self-contained
+Based on the study plan in `TODO.md`:
 
-That keeps every solution easy to review in isolation and close to the format used on LeetCode itself.
+- **Two Pointers** — palindrome checks, container problems, sorted-array search
+- **Binary Search** — insert position, range search, rotated arrays
+- **Prefix Sum** — range queries, subarray sums
+- **DFS / BFS** — tree traversals, grid search, shortest paths
+- **Recursion / Backtracking** — subsets, parentheses, combinatorial search
+- **Queue** — rolling windows, circular buffers
+- **Trie** — prefix matching, word search
 
 ## Daily Problem Automation
 
-The repository includes a GitHub Actions workflow that runs daily and opens an issue for the current LeetCode daily problem.
+A scheduled GitHub Actions workflow runs daily at 06:15 CET and:
 
-Current behavior:
+1. Queries the LeetCode GraphQL API for the current daily problem
+2. Opens a GitHub Issue if one does not already exist for that day
 
-- the workflow runs on a schedule and also supports manual dispatch
-- it queries the LeetCode GraphQL API for the current daily problem
-- it creates an issue only if an open issue for that day does not already exist
-
-This automation is implemented with:
-
-- GitHub Actions workflow YAML in `.github/workflows/daily-problem.yml`
-- a small Node-based custom action in `.github/actions/daily-problem/index.js`
+This can also be triggered manually via `workflow_dispatch`.
 
 ## Practice Philosophy
 
-This repo is for practice, not for outsourcing unsolved DSA work.
-
-That means the preferred workflow is:
+This repo is for personal practice. The goal is to build consistent DSA skills over time:
 
 - solve or attempt problems personally
-- use the repo to store finished or iterated solutions
-- use agents for review, edge cases, debugging help, refactoring, and repository improvements
-- avoid having agents fully solve unsolved LeetCode problems from scratch
+- store finished and iterated solutions
+- use agents for review, edge cases, debugging, and refactoring — not for solving unsolved problems
 
-## Working With Agents
+## Commit Conventions
 
-This repo is set up to work well with coding agents, but with clear boundaries.
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/):
 
-Agents are useful here for:
+| Type | Usage | Example |
+|------|-------|---------|
+| `feat` | new solution or feature | `feat(35): add binary search solution` |
+| `fix` | bug fix in a solution or action | `fix(ci): update node version` |
+| `refactor` | improve an existing solution | `refactor(42): simplify two-pointer logic` |
+| `docs` | documentation changes | `docs: expand README` |
+| `chore` | maintenance, tooling, CI | `chore: add .editorconfig` |
 
-- reviewing an existing solution for correctness or clarity
-- suggesting the smallest improvement to a solution
-- explaining time and space complexity
-- debugging a failing approach
-- improving the GitHub Action or repository docs
-- preparing commits and pull requests
+## Verification
 
-For repo-specific guidance, see `AGENTS.md`.
+There is no automated test suite. Verification is intentionally lightweight:
 
-## Commit Style
-
-For problem solutions, commits follow this format:
-
-`problem(<id>): <technique>`
-
-Examples:
-
-- `problem(35): binary search`
-- `problem(2078): bottom-up two-pointers`
-- `problem(3488): hash-table & binary search`
-
-For docs or automation changes, use a short imperative commit message that describes the change.
-
-## Verification Approach
-
-There is no full automated test suite for the problem files, so verification is intentionally lightweight.
-
-Typical checks are:
-
-- validate logic against the main examples and edge cases
+- validate logic against the problem's examples and edge cases
 - run a local harness if a problem file includes one
-- for GitHub Action changes, run `npm ci` and `node --check .github/actions/daily-problem/index.js`
+- for GitHub Action changes: `npm ci` and `node --check .github/actions/daily-problem/index.js`
 
-## Why This Repo Exists
+## License
 
-The main purpose of this repository is to build consistent DSA practice over time while keeping the process lightweight:
-
-- one file per solved problem
-- one issue per daily prompt
-- minimal tooling
-- clear history in Git
-
-That makes it easy to practice, review progress, and experiment with agent-assisted workflows without turning the repo into a large framework.
+Released into the public domain under the [Unlicense](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LeetCode Practice
 
+[![Python CI](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/python-ci.yml?label=ruff&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/python-ci.yml)
 [![Daily Problem](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/daily-problem.yml?label=daily%20automation&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/daily-problem.yml)
 [![Issues](https://img.shields.io/github/issues/kovacoj1/leetcode?style=flat-square)](https://github.com/kovacoj1/leetcode/issues)
 [![License](https://img.shields.io/github/license/kovacoj1/leetcode?style=flat-square)](LICENSE)
@@ -78,6 +79,7 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/):
 
 There is no automated test suite. Verification is intentionally lightweight:
 
+- **Python CI**: Ruff checks lint (`E`, `F`, `W`, `UP`, `I`) and format on every push/PR that touches `problems/`
 - validate logic against the problem's examples and edge cases
 - run a local harness if a problem file includes one
 - for GitHub Action changes: `npm ci` and `node --check .github/actions/daily-problem/index.js`

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+target-version = "py312"
+
+[lint]
+select = ["E", "F", "W", "UP", "I"]
+ignore = [
+    "E501",
+    "F821",
+    "UP035",
+]
+
+[format]
+docstring-code-format = true


### PR DESCRIPTION
## Summary

Make this repository CV-ready by adding standard project files, polishing the README, and introducing Python CI.

### Commits

| Commit | Change |
|--------|--------|
| `chore: add Unlicense` | LICENSE file — public domain dedication |
| `chore: add .editorconfig and expand .gitignore` | consistent editor settings; ignore `__pycache__`, `.pyc`, `.env`, `.claude/` |
| `docs: polish README for public profile` | badges, topic overview, example table, recruiter-friendly structure |
| `docs: adopt conventional commits` | update AGENTS.md commit conventions to Conventional Commits format |
| `feat(ci): add Python lint and format checks with Ruff` | new `python-ci.yml` workflow + `ruff.toml` config |
| `docs: add Python CI badge and update verification section` | CI badge in README, verification docs mention Ruff |

### Why

- A repo shared on a CV should have a license, consistent tooling, CI, and a README that explains itself without reading source files
- Conventional Commits make the git history scannable and professional
- Ruff CI catches lint errors, unused imports, and formatting issues on every push/PR that touches Python files — with zero config maintenance
- The Ruff config is intentionally lenient for LeetCode code (ignores `E501` line length, `F821` undefined names from LeetCode stubs, `UP035` deprecated typing)

### Verification

- all 6 commits use Conventional Commits format
- `ruff.toml` targets Python 3.12 with a minimal rule set appropriate for self-contained LeetCode solutions
- `python-ci.yml` only triggers on changes to `problems/**/*.py` to avoid unnecessary runs
- README badges reference the correct workflow filenames
- no solution files or GitHub Action behavior were modified