### PR TITLE
fix(ci): scope Ruff checks to changed solution files

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,15 +25,39 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: astral-sh/ruff-action@v3
+      - name: Collect changed Python files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
         with:
-          args: check --select=E,F,W,UP,I --ignore=E501
+          files: problems/**/*.py
+
+      - name: Skip when no Python files changed
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: |
+          echo "No Python solution files changed."
+
+      - uses: astral-sh/ruff-action@v3
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          args: check --select=E,F,W,UP,I --ignore=E501 ${{ steps.changed-files.outputs.all_changed_files }}
 
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
-      - uses: astral-sh/ruff-action@v3
+      - name: Collect changed Python files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
         with:
-          args: format --check
+          files: problems/**/*.py
+
+      - name: Skip when no Python files changed
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: |
+          echo "No Python solution files changed."
+
+      - uses: astral-sh/ruff-action@v3
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          args: format --check ${{ steps.changed-files.outputs.all_changed_files }}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/):
 
 There is no automated test suite. Verification is intentionally lightweight:
 
-- **Python CI**: Ruff checks lint (`E`, `F`, `W`, `UP`, `I`) and format on every push/PR that touches `problems/` or Python CI config
+- **Python CI**: Ruff checks lint (`E`, `F`, `W`, `UP`, `I`) and format for changed `problems/*.py` files, plus manual CI/config validation via workflow dispatch
 - validate logic against the problem's examples and edge cases
 - run a local harness if a problem file includes one
 - for GitHub Action changes: `npm ci` and `node --check .github/actions/daily-problem/index.js`


### PR DESCRIPTION
## Summary
- change `Python CI` to lint and format only changed `problems/*.py` files
- keep `workflow_dispatch` support for manual validation
- update the README verification note to match the actual CI behavior

## Why
- the previous workflow ran `ruff format --check` across the entire repository
- that immediately failed on pre-existing formatting drift in legacy solution files and made the new CI impractical to use
- for this repository, incremental checks are the better tradeoff: new and modified solutions are kept clean without forcing a massive formatting migration

## Verification
- reviewed the current merged `Python CI` workflow on `main`
- updated the workflow to use `tj-actions/changed-files` for `problems/**/*.py`
- confirmed the diff is limited to `.github/workflows/python-ci.yml` and `README.md`