### PR TITLE
feat(repo): improve public repo presentation and automation

### DIFF
--- a/.github/actions/daily-problem/action.yml
+++ b/.github/actions/daily-problem/action.yml
@@ -3,6 +3,8 @@ description: "Fetch the frontend ID of the current LeetCode daily problem"
 outputs:
   problem_id:
     description: "LeetCode frontend problem ID"
+  problem_slug:
+    description: "LeetCode problem title slug"
 runs:
   using: "node24"
   main: "index.js"

--- a/.github/actions/daily-problem/index.js
+++ b/.github/actions/daily-problem/index.js
@@ -15,6 +15,7 @@ async function run() {
             activeDailyCodingChallengeQuestion {
               question {
                 questionFrontendId
+                titleSlug
               }
             }
           }
@@ -30,12 +31,15 @@ async function run() {
         const payload = await response.json();
         const problemId =
             payload?.data?.activeDailyCodingChallengeQuestion?.question?.questionFrontendId;
+        const problemSlug =
+            payload?.data?.activeDailyCodingChallengeQuestion?.question?.titleSlug;
 
-        if (!problemId) {
-            throw new Error("questionFrontendId was not found in the response");
+        if (!problemId || !problemSlug) {
+            throw new Error("Daily problem metadata was not found in the response");
         }
 
         core.setOutput("problem_id", String(problemId));
+        core.setOutput("problem_slug", String(problemSlug));
     } catch (error) {
         core.setFailed(error instanceof Error ? error.message : String(error));
     }

--- a/.github/workflows/daily-problem.yml
+++ b/.github/workflows/daily-problem.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: daily-problem
+  cancel-in-progress: false
+
 jobs:
   create-daily-issue:
     runs-on: ubuntu-latest
@@ -40,7 +44,20 @@ jobs:
           script: |
             const today = "${{ steps.date.outputs.today }}";
             const problemId = "${{ steps.dailycode.outputs.problem_id }}";
+            const problemSlug = "${{ steps.dailycode.outputs.problem_slug }}";
             const title = `problem(${problemId}): solve daily problem [${today}]`;
+            const labels = [
+              {
+                name: "daily-problem",
+                color: "1d76db",
+                description: "Automatically created daily LeetCode practice item"
+              },
+              {
+                name: "practice",
+                color: "5319e7",
+                description: "Practice backlog item"
+              }
+            ];
 
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -50,9 +67,37 @@ jobs:
 
             if (issues.some(issue => issue.title === title)) return;
 
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              }
+            }
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title,
-              body: `Solve LeetCode daily problem #${problemId}.`
+              labels: labels.map(label => label.name),
+              body: [
+                `Daily LeetCode practice item for ${today}.`,
+                "",
+                `- Problem ID: ${problemId}`,
+                `- Link: https://leetcode.com/problems/${problemSlug}/`,
+                "",
+                "Use this issue to track your attempt, notes, and follow-up cleanup."
+              ].join("\n")
             });

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,32 @@ permissions:
   contents: read
 
 jobs:
+  syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Collect changed Python files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: problems/**/*.py
+
+      - name: Skip when no Python files changed
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: |
+          echo "No Python solution files changed."
+
+      - name: Compile changed Python files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          python -m py_compile ${{ steps.changed-files.outputs.all_changed_files }}
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +65,7 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
+          version: "0.15.11"
           args: check --select=E,F,W,UP,I --ignore=E501 ${{ steps.changed-files.outputs.all_changed_files }}
 
   format:
@@ -60,4 +87,5 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
+          version: "0.15.11"
           args: format --check ${{ steps.changed-files.outputs.all_changed_files }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Agents are a strong fit for:
 - Explaining time and space complexity for a solution.
 - Giving hints or partial guidance on a problem without fully solving it.
 - Updating the daily GitHub Action.
+- Updating repository metadata, README quality, and lightweight CI.
 - Preparing a branch, commit, or PR summary.
 
 Agents are a weaker fit for:
@@ -119,7 +120,6 @@ Use prompts like these:
 
 - `Review my solution in problems/42.trapping-rain-water.py for correctness, edge cases, and unnecessary complexity. Suggest the smallest improvement.`
 - `Give me a hint for today's LeetCode daily problem without solving it.`
-- `Review problems/42.trapping-rain-water.py for correctness, edge cases, and unnecessary complexity. Suggest the smallest improvement.`
 - `Update the daily GitHub Action to fail more clearly when the LeetCode API shape changes. Keep the change minimal and verify syntax.`
 - `Prepare a PR summary for the current branch based on all changes since main.`
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # LeetCode Practice
 
-[![Python CI](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/python-ci.yml?label=ruff&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/python-ci.yml)
-[![Daily Problem](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/daily-problem.yml?label=daily%20automation&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/daily-problem.yml)
+[![Python CI](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/python-ci.yml?branch=main&label=python%20ci&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/python-ci.yml)
+[![Daily Automation](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/daily-problem.yml?branch=main&label=daily%20automation&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/daily-problem.yml)
 [![Python](https://img.shields.io/badge/python-3.12-blue?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/kovacoj1/leetcode?style=flat-square)](LICENSE)
 
-A structured data structures and algorithms practice repository with automated daily problem tracking.
+Public record of my data structures and algorithms practice in Python, with lightweight CI and a custom GitHub Actions workflow for daily LeetCode tracking.
 
 ## What This Is
 
-This repo is a personal DSA practice log. Each problem is a single self-contained Python file, organized by LeetCode problem ID. A GitHub Actions workflow automatically creates a daily issue for the current LeetCode problem, keeping practice consistent over time.
+This repository shows how I approach algorithm practice as an engineering project rather than a pile of scratch files.
+
+It demonstrates:
+
+- self-contained Python problem solving
+- consistent file and commit conventions
+- custom GitHub Actions automation
+- lightweight CI with Ruff on changed solution files
+
+Each problem is stored as a single Python file named by LeetCode problem ID and slug.
 
 ## Repository Structure
 
@@ -20,6 +29,13 @@ problems/<id>.<slug>.py     # one file per solved problem
 AGENTS.md                   # agent workflow guidance
 TODO.md                     # study plan and topic roadmap
 ```
+
+## Snapshot
+
+- growing set of single-file Python solutions in `problems/`
+- custom GitHub Action for daily problem issue creation
+- Ruff-based Python CI for changed solution files
+- Conventional Commits for readable history
 
 ### Problem Files
 
@@ -32,11 +48,18 @@ Each solution follows the naming convention `problems/<id>.<slug>.py`:
 | `208.implement-trie-prefix-tree.py` | Implement Trie | Trie |
 | `494.target-sum.py` | Target Sum | Memoized DFS |
 
-Solutions are intentionally self-contained — no shared modules, no framework, just a clean `class Solution` implementation per file.
+Solutions are intentionally self-contained: no shared helper package, no abstraction layer, just a focused `class Solution` implementation per file.
+
+## Selected Examples
+
+- [`problems/42.trapping-rain-water.py`](./problems/42.trapping-rain-water.py): two-pointer technique
+- [`problems/208.implement-trie-prefix-tree.py`](./problems/208.implement-trie-prefix-tree.py): trie data structure
+- [`problems/494.target-sum.py`](./problems/494.target-sum.py): memoized DFS
+- [`problems/3488.closest-equal-element-queries.py`](./problems/3488.closest-equal-element-queries.py): hashing with indexed search
 
 ## Topics Covered
 
-Based on the study plan in `TODO.md`:
+Based on the study plan in [`TODO.md`](./TODO.md):
 
 - **Two Pointers** — palindrome checks, container problems, sorted-array search
 - **Binary Search** — insert position, range search, rotated arrays
@@ -51,13 +74,15 @@ Based on the study plan in `TODO.md`:
 A scheduled GitHub Actions workflow runs daily at 06:15 UTC and:
 
 1. Queries the LeetCode GraphQL API for the current daily problem
-2. Opens a GitHub Issue if one does not already exist for that day
+2. Opens a labeled GitHub Issue if one does not already exist for that day
 
 This can also be triggered manually via `workflow_dispatch`.
 
+Open daily issues are intentional practice backlog items, not product bugs.
+
 ## Practice Philosophy
 
-This repo is for personal practice. The goal is to build consistent DSA skills over time:
+This repo is for personal practice. The goal is to build consistent DSA skills over time while keeping the work reviewable and publishable:
 
 - solve or attempt problems personally
 - store finished and iterated solutions
@@ -77,9 +102,10 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/):
 
 ## Verification
 
-There is no automated test suite. Verification is intentionally lightweight:
+There is no full automated test suite. Verification is intentionally lightweight:
 
-- **Python CI**: Ruff checks lint (`E`, `F`, `W`, `UP`, `I`) and format for changed `problems/*.py` files, plus manual CI/config validation via workflow dispatch
+- **Python CI**: Ruff checks lint (`E`, `F`, `W`, `UP`, `I`) and format for changed `problems/*.py` files
+- **Syntax smoke check**: changed `problems/*.py` files are compiled with Python to catch syntax errors early
 - validate logic against the problem's examples and edge cases
 - run a local harness if a problem file includes one
 - for GitHub Action changes: `npm ci` and `node --check .github/actions/daily-problem/index.js`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,25 @@
+# Study Plan
+
+This file tracks the main DSA topics I want to practice in this repository.
+
+## Topics
+
+1. Trie
+2. DFS / BFS
+3. Prefix Sum
+4. Recursion / Backtracking
+5. Queue
+6. Binary Search
+7. Two Pointers
+
+## Current Focus
+
+- Keep solutions self-contained and easy to review
+- Prioritize correctness, edge cases, and clear algorithm choice
+- Use the daily issue automation to maintain consistency
+
+## Notes
+
+- This repository is a practice log, not a full solutions library
+- Unsolved problems should stay unsolved until I attempt them myself
+- Agents should help with review, debugging, and explanation rather than solving fresh practice problems from scratch


### PR DESCRIPTION
## Summary
- strengthen the public-facing README so the repository reads like a real portfolio project rather than a loose practice dump
- add a tracked `TODO.md` study plan to align the public docs with actual repository files
- expand Python CI with a syntax smoke check and keep Ruff checks scoped to changed solution files
- improve the daily problem automation by exposing the LeetCode slug, linking issues to the exact problem, and auto-creating useful labels
- update `AGENTS.md` with a small repo-maintenance guidance improvement
- set public GitHub repo metadata: description and topics

## Why
- this repository is now public and intended to be shareable on a CV, so it should communicate engineering quality, consistency, and intent quickly
- the README should show what the project demonstrates, how the automation works, and why the issue backlog exists
- the daily workflow should create richer, more structured issues so the public issue list looks intentional instead of noisy
- lightweight CI should catch syntax and lint/format issues on changed Python solutions without forcing a repository-wide reformat

## Verification
- reviewed the current public repository state, workflow files, and tracked docs on `main`
- ran `node --check .github/actions/daily-problem/index.js` to verify the custom action syntax
- confirmed the diff is limited to docs, CI, and daily automation files plus the new tracked `TODO.md`
- updated GitHub repository metadata via `gh repo edit` to add a description and topics