### PR TITLE
feat(docs): add GitHub Pages topic browser

### DIFF
--- a/.github/workflows/topic-browser.yml
+++ b/.github/workflows/topic-browser.yml
@@ -1,0 +1,56 @@
+name: Deploy Topic Browser
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "problems/**/*.py"
+      - "scripts/generate-topic-browser.mjs"
+      - "site/**"
+      - ".github/workflows/topic-browser.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Generate topic browser data
+        run: node scripts/generate-topic-browser.mjs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyo
 .env
 .claude/
+site/data.json

--- a/README.md
+++ b/README.md
@@ -20,12 +20,22 @@ It demonstrates:
 
 Each problem is stored as a single Python file named by LeetCode problem ID and slug.
 
+## Topic Browser
+
+Browse solved problems by inferred topic on GitHub Pages:
+
+- <https://kovacoj1.github.io/leetcode/>
+
+The topic browser is generated from git history. It uses the commit messages that touched each tracked problem file to infer topics such as `Two Pointers`, `Binary Search`, `DFS / BFS`, and `Trie`.
+
 ## Repository Structure
 
 ```
 problems/<id>.<slug>.py     # one file per solved problem
 .github/workflows/          # daily problem automation
 .github/actions/            # custom action: fetch daily LeetCode ID
+scripts/                    # lightweight repo tooling
+site/                       # GitHub Pages topic browser source
 AGENTS.md                   # agent workflow guidance
 TODO.md                     # study plan and topic roadmap
 ```

--- a/scripts/generate-topic-browser.mjs
+++ b/scripts/generate-topic-browser.mjs
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outputPath = path.join(rootDir, "site", "data.json");
+
+const topicDefinitions = [
+  { name: "Two Pointers", patterns: [/\btwo[- ]pointers?\b/i] },
+  { name: "Binary Search", patterns: [/\bbinary[- ]search\b/i] },
+  { name: "Prefix Sum", patterns: [/\bprefix[- ]sum\b/i] },
+  { name: "DFS / BFS", patterns: [/\bdfs\b/i, /\bbfs\b/i] },
+  { name: "Trie", patterns: [/\btrie\b/i] },
+  { name: "Queue", patterns: [/\bqueue\b/i] },
+  {
+    name: "Recursion / Backtracking",
+    patterns: [/\brecurs(?:ion|ive)\b/i, /\bbacktracking\b/i],
+  },
+  { name: "Dynamic Programming", patterns: [/\bdp\b/i, /dynamic programming/i] },
+  { name: "Hashing", patterns: [/\bhash[- ]table\b/i, /\bhashmap\b/i, /\bhash map\b/i] },
+  { name: "Counting", patterns: [/\bcounter\b/i, /\bcounting\b/i] },
+  { name: "Heap", patterns: [/\bheap\b/i] },
+  { name: "Tree", patterns: [/\btree\b/i] },
+  { name: "Greedy", patterns: [/\bgreedy\b/i] },
+];
+
+function runGit(args) {
+  return execFileSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf8",
+  }).trim();
+}
+
+function normalizeRepoUrl(remoteUrl) {
+  if (remoteUrl.startsWith("git@github.com:")) {
+    return `https://github.com/${remoteUrl.slice("git@github.com:".length).replace(/\.git$/, "")}`;
+  }
+
+  return remoteUrl.replace(/\.git$/, "");
+}
+
+function toTitleCase(slug) {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function extractTopics(subjects) {
+  const topics = new Set();
+
+  for (const subject of subjects) {
+    const scopedMatch = subject.match(/^[a-z]+(?:\(([^)]+)\))?:\s*(.*)$/i);
+    const text = scopedMatch
+      ? [scopedMatch[1], scopedMatch[2]].filter(Boolean).join(" ")
+      : subject;
+
+    for (const topic of topicDefinitions) {
+      if (topic.patterns.some((pattern) => pattern.test(text))) {
+        topics.add(topic.name);
+      }
+    }
+  }
+
+  if (topics.size === 0) {
+    topics.add("Uncategorized");
+  }
+
+  const orderedTopicNames = topicDefinitions.map((topic) => topic.name);
+  return Array.from(topics).sort((left, right) => {
+    const leftIndex = orderedTopicNames.indexOf(left);
+    const rightIndex = orderedTopicNames.indexOf(right);
+
+    if (leftIndex === -1 && rightIndex === -1) {
+      return left.localeCompare(right);
+    }
+
+    if (leftIndex === -1) {
+      return 1;
+    }
+
+    if (rightIndex === -1) {
+      return -1;
+    }
+
+    return leftIndex - rightIndex;
+  });
+}
+
+const repoUrl = normalizeRepoUrl(runGit(["config", "--get", "remote.origin.url"]));
+const files = runGit(["ls-files", "problems/*.py"])
+  .split("\n")
+  .filter(Boolean)
+  .sort((left, right) => {
+    const leftId = Number(path.basename(left).split(".", 1)[0]);
+    const rightId = Number(path.basename(right).split(".", 1)[0]);
+    return leftId - rightId;
+  });
+
+const problems = files.map((file) => {
+  const basename = path.basename(file, ".py");
+  const firstDotIndex = basename.indexOf(".");
+  const id = basename.slice(0, firstDotIndex);
+  const slug = basename.slice(firstDotIndex + 1);
+  const subjects = runGit(["log", "--follow", "--format=%s", "--", file])
+    .split("\n")
+    .filter(Boolean);
+
+  return {
+    id: Number(id),
+    slug,
+    title: toTitleCase(slug),
+    path: file,
+    url: `${repoUrl}/blob/main/${file}`,
+    topics: extractTopics(subjects),
+    commitSubjects: subjects,
+  };
+});
+
+const topicMap = new Map();
+
+for (const problem of problems) {
+  for (const topic of problem.topics) {
+    if (!topicMap.has(topic)) {
+      topicMap.set(topic, []);
+    }
+
+    topicMap.get(topic).push(problem.id);
+  }
+}
+
+const orderedTopicNames = [
+  ...topicDefinitions.map((topic) => topic.name).filter((name) => topicMap.has(name)),
+  ...Array.from(topicMap.keys())
+    .filter((name) => !topicDefinitions.some((topic) => topic.name === name))
+    .sort((left, right) => left.localeCompare(right)),
+];
+
+const data = {
+  generatedAt: new Date().toISOString(),
+  repoUrl,
+  totalProblems: problems.length,
+  topics: orderedTopicNames.map((name) => ({
+    name,
+    count: topicMap.get(name)?.length ?? 0,
+  })),
+  problems,
+};
+
+mkdirSync(path.dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(data, null, 2)}\n`);

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,144 @@
+const topicSelect = document.querySelector("#topic-select");
+const topicList = document.querySelector("#topic-list");
+const resultsTitle = document.querySelector("#results-title");
+const resultsCount = document.querySelector("#results-count");
+const resultsBody = document.querySelector("#results-body");
+const resultsTable = document.querySelector("#results-table");
+const resultsEmpty = document.querySelector("#results-empty");
+const problemCount = document.querySelector("#problem-count");
+const topicCount = document.querySelector("#topic-count");
+const generatedAt = document.querySelector("#generated-at");
+
+function formatGeneratedDate(value) {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function renderTopics(data, currentTopic) {
+  topicList.innerHTML = "";
+
+  const allTopics = [{ name: "All Topics", count: data.totalProblems }, ...data.topics];
+
+  for (const topic of allTopics) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `topic-pill${topic.name === currentTopic ? " active" : ""}`;
+    button.textContent = `${topic.name} (${topic.count})`;
+    button.addEventListener("click", () => {
+      topicSelect.value = topic.name;
+      renderResults(data, topic.name);
+    });
+    topicList.append(button);
+  }
+}
+
+function renderResults(data, topicName) {
+  const selectedTopic = topicName || "All Topics";
+  const filteredProblems = selectedTopic === "All Topics"
+    ? data.problems
+    : data.problems.filter((problem) => problem.topics.includes(selectedTopic));
+
+  window.location.hash = selectedTopic === "All Topics"
+    ? ""
+    : encodeURIComponent(selectedTopic.toLowerCase().replace(/\s+/g, "-"));
+
+  resultsTitle.textContent = selectedTopic === "All Topics"
+    ? "All solved problems"
+    : `${selectedTopic} problems`;
+  resultsCount.textContent = `${filteredProblems.length} result${filteredProblems.length === 1 ? "" : "s"}`;
+
+  renderTopics(data, selectedTopic);
+  resultsBody.innerHTML = "";
+
+  if (filteredProblems.length === 0) {
+    resultsTable.classList.add("hidden");
+    resultsEmpty.classList.remove("hidden");
+    return;
+  }
+
+  resultsTable.classList.remove("hidden");
+  resultsEmpty.classList.add("hidden");
+
+  for (const problem of filteredProblems) {
+    const row = document.createElement("tr");
+
+    const idCell = document.createElement("td");
+    idCell.textContent = String(problem.id);
+
+    const titleCell = document.createElement("td");
+    const link = document.createElement("a");
+    link.href = problem.url;
+    link.textContent = problem.title;
+    link.target = "_blank";
+    link.rel = "noreferrer";
+    titleCell.append(link);
+
+    const topicsCell = document.createElement("td");
+    const topicWrapper = document.createElement("div");
+    topicWrapper.className = "tag-list";
+
+    for (const topic of problem.topics) {
+      const tag = document.createElement("span");
+      tag.className = "tag";
+      tag.textContent = topic;
+      topicWrapper.append(tag);
+    }
+
+    topicsCell.append(topicWrapper);
+    row.append(idCell, titleCell, topicsCell);
+    resultsBody.append(row);
+  }
+}
+
+function resolveInitialTopic(data) {
+  const topicSlug = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+
+  if (!topicSlug) {
+    return "All Topics";
+  }
+
+  const match = data.topics.find(
+    (topic) => topic.name.toLowerCase().replace(/\s+/g, "-") === topicSlug,
+  );
+
+  return match?.name ?? "All Topics";
+}
+
+async function main() {
+  const response = await fetch("./data.json", { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load topic data (${response.status})`);
+  }
+
+  const data = await response.json();
+
+  problemCount.textContent = String(data.totalProblems);
+  topicCount.textContent = String(data.topics.length);
+  generatedAt.textContent = formatGeneratedDate(data.generatedAt);
+
+  topicSelect.innerHTML = "";
+  for (const topic of [{ name: "All Topics" }, ...data.topics]) {
+    const option = document.createElement("option");
+    option.value = topic.name;
+    option.textContent = topic.name;
+    topicSelect.append(option);
+  }
+
+  const initialTopic = resolveInitialTopic(data);
+  topicSelect.value = initialTopic;
+  renderResults(data, initialTopic);
+
+  topicSelect.addEventListener("change", () => {
+    renderResults(data, topicSelect.value);
+  });
+}
+
+main().catch((error) => {
+  resultsTable.classList.add("hidden");
+  resultsEmpty.textContent = error.message;
+  resultsEmpty.classList.remove("hidden");
+});

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LeetCode Topic Browser</title>
+    <meta
+      name="description"
+      content="Browse solved LeetCode problems by inferred topic based on git history."
+    >
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <main class="page">
+      <header class="hero">
+        <p class="eyebrow">GitHub Pages</p>
+        <h1>LeetCode Topic Browser</h1>
+        <p class="lede">
+          Browse solved problems by inferred topic. Topics are derived from the git commit
+          messages that touched each tracked solution file.
+        </p>
+        <p class="links">
+          <a href="https://github.com/kovacoj1/leetcode">Repository</a>
+          <span>•</span>
+          <a href="https://github.com/kovacoj1/leetcode/blob/main/README.md">README</a>
+        </p>
+      </header>
+
+      <section class="panel summary" id="summary">
+        <div>
+          <span class="label">Solved problems</span>
+          <strong id="problem-count">-</strong>
+        </div>
+        <div>
+          <span class="label">Topics</span>
+          <strong id="topic-count">-</strong>
+        </div>
+        <div>
+          <span class="label">Generated</span>
+          <strong id="generated-at">-</strong>
+        </div>
+      </section>
+
+      <section class="panel controls">
+        <label for="topic-select">Select topic</label>
+        <select id="topic-select"></select>
+        <p class="hint">
+          Historical topics are inferred heuristically, so older commits may be broader than newer
+          ones.
+        </p>
+      </section>
+
+      <section class="panel topics">
+        <h2>Topics</h2>
+        <div id="topic-list" class="topic-list"></div>
+      </section>
+
+      <section class="panel results">
+        <div class="results-header">
+          <h2 id="results-title">All solved problems</h2>
+          <span id="results-count" class="results-count"></span>
+        </div>
+        <div id="results-empty" class="empty hidden">No solved problems found for this topic.</div>
+        <table id="results-table" class="results-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Problem</th>
+              <th>Topics</th>
+            </tr>
+          </thead>
+          <tbody id="results-body"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,226 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --border: #d8dee9;
+  --text: #172033;
+  --muted: #5f6b82;
+  --accent: #275efe;
+  --accent-soft: #e8eeff;
+  --shadow: 0 14px 40px rgba(23, 32, 51, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: linear-gradient(180deg, #eef3ff 0%, var(--bg) 220px);
+  color: var(--text);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.page {
+  width: min(1100px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 56px;
+}
+
+.hero {
+  padding: 8px 4px 24px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(34px, 6vw, 52px);
+  line-height: 1.05;
+}
+
+.lede {
+  max-width: 760px;
+  margin: 16px 0 0;
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.links {
+  margin: 18px 0 0;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: var(--muted);
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 20px;
+  margin-top: 18px;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.summary strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 24px;
+}
+
+.label {
+  color: var(--muted);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.controls label {
+  font-weight: 600;
+}
+
+.controls select {
+  width: min(360px, 100%);
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+  font: inherit;
+}
+
+.hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.topics h2,
+.results h2 {
+  margin: 0 0 14px;
+  font-size: 18px;
+}
+
+.topic-list,
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.topic-pill,
+.tag {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #fff;
+  padding: 8px 12px;
+  font: inherit;
+}
+
+.topic-pill {
+  cursor: pointer;
+}
+
+.topic-pill.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.tag {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.results-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+  margin-bottom: 14px;
+}
+
+.results-count {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.results-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.results-table th,
+.results-table td {
+  text-align: left;
+  padding: 14px 10px;
+  border-top: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.results-table th {
+  color: var(--muted);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.empty {
+  padding: 18px;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: var(--muted);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  .page {
+    width: min(100% - 20px, 1100px);
+    padding-top: 20px;
+  }
+
+  .panel {
+    padding: 16px;
+  }
+
+  .results-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .results-table th:nth-child(3),
+  .results-table td:nth-child(3) {
+    min-width: 180px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a GitHub Pages topic browser under `site/` that lets you filter solved problems by inferred topic
- generate the topic data from real git history using `scripts/generate-topic-browser.mjs`
- add a Pages deployment workflow and enable GitHub Pages for the repository
- link the topic browser from the README

## How it works
- tracked `problems/*.py` files are read from git
- commit subjects for each file are collected with `git log --follow --format=%s -- <file>`
- topics such as `Two Pointers`, `Binary Search`, `DFS / BFS`, `Trie`, and others are inferred heuristically from those commit messages
- the generator writes `site/data.json` during deployment, which is then rendered by a small static browser app on GitHub Pages

## Why
- this gives you a simple public-facing way to answer: \"Which solved problems do I have in this topic?\"
- it stays close to your existing workflow because it uses the topic hints you already put into commit messages
- it avoids adding a database, framework, or manual topic-maintenance process

## Verification
- ran `node scripts/generate-topic-browser.mjs` locally to verify the generated topic data
- reviewed the inferred topic groupings for the tracked problems on `main`
- enabled GitHub Pages in workflow mode for the repository via the GitHub API