### PR TITLE
refactor(docs): simplify topic browser layout

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -1,21 +1,9 @@
-const topicSelect = document.querySelector("#topic-select");
 const topicList = document.querySelector("#topic-list");
 const resultsTitle = document.querySelector("#results-title");
 const resultsCount = document.querySelector("#results-count");
 const resultsBody = document.querySelector("#results-body");
 const resultsTable = document.querySelector("#results-table");
 const resultsEmpty = document.querySelector("#results-empty");
-const problemCount = document.querySelector("#problem-count");
-const topicCount = document.querySelector("#topic-count");
-const generatedAt = document.querySelector("#generated-at");
-
-function formatGeneratedDate(value) {
-  const date = new Date(value);
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
-}
 
 function renderTopics(data, currentTopic) {
   topicList.innerHTML = "";
@@ -28,7 +16,6 @@ function renderTopics(data, currentTopic) {
     button.className = `topic-pill${topic.name === currentTopic ? " active" : ""}`;
     button.textContent = `${topic.name} (${topic.count})`;
     button.addEventListener("click", () => {
-      topicSelect.value = topic.name;
       renderResults(data, topic.name);
     });
     topicList.append(button);
@@ -116,25 +103,8 @@ async function main() {
 
   const data = await response.json();
 
-  problemCount.textContent = String(data.totalProblems);
-  topicCount.textContent = String(data.topics.length);
-  generatedAt.textContent = formatGeneratedDate(data.generatedAt);
-
-  topicSelect.innerHTML = "";
-  for (const topic of [{ name: "All Topics" }, ...data.topics]) {
-    const option = document.createElement("option");
-    option.value = topic.name;
-    option.textContent = topic.name;
-    topicSelect.append(option);
-  }
-
   const initialTopic = resolveInitialTopic(data);
-  topicSelect.value = initialTopic;
   renderResults(data, initialTopic);
-
-  topicSelect.addEventListener("change", () => {
-    renderResults(data, topicSelect.value);
-  });
 }
 
 main().catch((error) => {

--- a/site/index.html
+++ b/site/index.html
@@ -26,32 +26,12 @@
         </p>
       </header>
 
-      <section class="panel summary" id="summary">
-        <div>
-          <span class="label">Solved problems</span>
-          <strong id="problem-count">-</strong>
-        </div>
-        <div>
-          <span class="label">Topics</span>
-          <strong id="topic-count">-</strong>
-        </div>
-        <div>
-          <span class="label">Generated</span>
-          <strong id="generated-at">-</strong>
-        </div>
-      </section>
-
-      <section class="panel controls">
-        <label for="topic-select">Select topic</label>
-        <select id="topic-select"></select>
+      <section class="panel topics">
+        <h2>Topics</h2>
         <p class="hint">
           Historical topics are inferred heuristically, so older commits may be broader than newer
           ones.
         </p>
-      </section>
-
-      <section class="panel topics">
-        <h2>Topics</h2>
         <div id="topic-list" class="topic-list"></div>
       </section>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -79,46 +79,8 @@ a:hover {
   margin-top: 18px;
 }
 
-.summary {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 16px;
-}
-
-.summary strong {
-  display: block;
-  margin-top: 8px;
-  font-size: 24px;
-}
-
-.label {
-  color: var(--muted);
-  font-size: 13px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.controls {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.controls label {
-  font-weight: 600;
-}
-
-.controls select {
-  width: min(360px, 100%);
-  padding: 12px 14px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: #fff;
-  font: inherit;
-}
-
 .hint {
-  margin: 0;
+  margin: 0 0 14px;
   color: var(--muted);
   font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- remove the top summary banner from the topic browser
- remove the separate "Select topic" panel
- keep topic filtering through the topic pills only

## Why
- the extra top panels made the page feel busier than needed
- the topic pills already provide the filtering interaction, so the select box was redundant
- this keeps the GitHub Pages browser simpler and more focused on the solved-problems view

## Verification
- reviewed the layout diff locally
- confirmed the changes are limited to `site/index.html`, `site/app.js`, and `site/styles.css`