### PR TITLE
feat(docs): add solution and LeetCode links to topic browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # LeetCode Practice
 
-[![Python CI](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/python-ci.yml?branch=main&label=python%20ci&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/python-ci.yml)
-[![Daily Automation](https://img.shields.io/github/actions/workflow/status/kovacoj1/leetcode/daily-problem.yml?branch=main&label=daily%20automation&style=flat-square)](https://github.com/kovacoj1/leetcode/actions/workflows/daily-problem.yml)
+[![Python CI](https://img.shields.io/github/actions/workflow/status/kovacoj/leetcode/python-ci.yml?branch=main&label=python%20ci&style=flat-square)](https://github.com/kovacoj/leetcode/actions/workflows/python-ci.yml)
+[![Daily Automation](https://img.shields.io/github/actions/workflow/status/kovacoj/leetcode/daily-problem.yml?branch=main&label=daily%20automation&style=flat-square)](https://github.com/kovacoj/leetcode/actions/workflows/daily-problem.yml)
 [![Python](https://img.shields.io/badge/python-3.12-blue?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![License](https://img.shields.io/github/license/kovacoj1/leetcode?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/github/license/kovacoj/leetcode?style=flat-square)](LICENSE)
 
 Public record of my data structures and algorithms practice in Python, with lightweight CI and a custom GitHub Actions workflow for daily LeetCode tracking.
 
@@ -24,7 +24,7 @@ Each problem is stored as a single Python file named by LeetCode problem ID and 
 
 Browse solved problems by inferred topic on GitHub Pages:
 
-- <https://kovacoj1.github.io/leetcode/>
+- <https://kovacoj.github.io/leetcode/>
 
 The topic browser is generated from git history. It uses the commit messages that touched each tracked problem file to infer topics such as `Two Pointers`, `Binary Search`, `DFS / BFS`, and `Trie`.
 

--- a/scripts/generate-topic-browser.mjs
+++ b/scripts/generate-topic-browser.mjs
@@ -113,7 +113,8 @@ const problems = files.map((file) => {
     slug,
     title: toTitleCase(slug),
     path: file,
-    url: `${repoUrl}/blob/main/${file}`,
+    solutionUrl: `${repoUrl}/blob/main/${file}`,
+    leetcodeUrl: `https://leetcode.com/problems/${slug}/`,
     topics: extractTopics(subjects),
     commitSubjects: subjects,
   };

--- a/site/app.js
+++ b/site/app.js
@@ -56,26 +56,25 @@ function renderResults(data, topicName) {
     idCell.textContent = String(problem.id);
 
     const titleCell = document.createElement("td");
-    const link = document.createElement("a");
-    link.href = problem.url;
-    link.textContent = problem.title;
-    link.target = "_blank";
-    link.rel = "noreferrer";
-    titleCell.append(link);
+    titleCell.textContent = problem.title;
 
-    const topicsCell = document.createElement("td");
-    const topicWrapper = document.createElement("div");
-    topicWrapper.className = "tag-list";
+    const solutionCell = document.createElement("td");
+    const solutionLink = document.createElement("a");
+    solutionLink.href = problem.solutionUrl;
+    solutionLink.textContent = problem.path;
+    solutionLink.target = "_blank";
+    solutionLink.rel = "noreferrer";
+    solutionCell.append(solutionLink);
 
-    for (const topic of problem.topics) {
-      const tag = document.createElement("span");
-      tag.className = "tag";
-      tag.textContent = topic;
-      topicWrapper.append(tag);
-    }
+    const leetcodeCell = document.createElement("td");
+    const leetcodeLink = document.createElement("a");
+    leetcodeLink.href = problem.leetcodeUrl;
+    leetcodeLink.textContent = "Open problem";
+    leetcodeLink.target = "_blank";
+    leetcodeLink.rel = "noreferrer";
+    leetcodeCell.append(leetcodeLink);
 
-    topicsCell.append(topicWrapper);
-    row.append(idCell, titleCell, topicsCell);
+    row.append(idCell, titleCell, solutionCell, leetcodeCell);
     resultsBody.append(row);
   }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -20,9 +20,9 @@
           messages that touched each tracked solution file.
         </p>
         <p class="links">
-          <a href="https://github.com/kovacoj1/leetcode">Repository</a>
+          <a href="https://github.com/kovacoj/leetcode">Repository</a>
           <span>•</span>
-          <a href="https://github.com/kovacoj1/leetcode/blob/main/README.md">README</a>
+          <a href="https://github.com/kovacoj/leetcode/blob/main/README.md">README</a>
         </p>
       </header>
 
@@ -46,7 +46,8 @@
             <tr>
               <th>ID</th>
               <th>Problem</th>
-              <th>Topics</th>
+              <th>My Solution</th>
+              <th>LeetCode</th>
             </tr>
           </thead>
           <tbody id="results-body"></tbody>


### PR DESCRIPTION
## Summary
- update README and topic-browser links from `kovacoj1` to `kovacoj`
- change the topic-browser results table to include `My Solution` and `LeetCode` columns
- generate direct repository and LeetCode links for each tracked solved problem

## Why
- the public links should match the renamed GitHub account
- the topic browser is more useful when each row lets you jump directly to your own solution or to the original LeetCode problem statement

## Verification
- searched the repository for remaining `kovacoj1` references and updated the tracked ones
- regenerated local topic-browser data with `node scripts/generate-topic-browser.mjs`
- confirmed the topic browser table now renders four columns: ID, Problem, My Solution, and LeetCode