### PR TITLE
fix(docs): make topic browser links backward-compatible

### DIFF
--- a/scripts/generate-topic-browser.mjs
+++ b/scripts/generate-topic-browser.mjs
@@ -113,6 +113,7 @@ const problems = files.map((file) => {
     slug,
     title: toTitleCase(slug),
     path: file,
+    url: `${repoUrl}/blob/main/${file}`,
     solutionUrl: `${repoUrl}/blob/main/${file}`,
     leetcodeUrl: `https://leetcode.com/problems/${slug}/`,
     topics: extractTopics(subjects),

--- a/site/app.js
+++ b/site/app.js
@@ -51,6 +51,8 @@ function renderResults(data, topicName) {
 
   for (const problem of filteredProblems) {
     const row = document.createElement("tr");
+    const solutionUrl = problem.solutionUrl || problem.url || `https://github.com/kovacoj/leetcode/blob/main/${problem.path}`;
+    const leetcodeUrl = problem.leetcodeUrl || `https://leetcode.com/problems/${problem.slug}/`;
 
     const idCell = document.createElement("td");
     idCell.textContent = String(problem.id);
@@ -60,7 +62,7 @@ function renderResults(data, topicName) {
 
     const solutionCell = document.createElement("td");
     const solutionLink = document.createElement("a");
-    solutionLink.href = problem.solutionUrl;
+    solutionLink.href = solutionUrl;
     solutionLink.textContent = problem.path;
     solutionLink.target = "_blank";
     solutionLink.rel = "noreferrer";
@@ -68,7 +70,7 @@ function renderResults(data, topicName) {
 
     const leetcodeCell = document.createElement("td");
     const leetcodeLink = document.createElement("a");
-    leetcodeLink.href = problem.leetcodeUrl;
+    leetcodeLink.href = leetcodeUrl;
     leetcodeLink.textContent = "Open problem";
     leetcodeLink.target = "_blank";
     leetcodeLink.rel = "noreferrer";


### PR DESCRIPTION
## Summary
- add a compatibility `url` field back into generated topic-browser problem data
- make the browser compute safe fallbacks for both solution and LeetCode links

## Why
- the deployed Pages site can temporarily serve a cached mix of old JS and new generated data, or vice versa
- that mismatch can surface as `undefined` links even when the latest code is correct
- this change makes the topic browser resilient to those short-lived cache mismatches

## Verification
- regenerated local topic-browser data with `node scripts/generate-topic-browser.mjs`
- confirmed generated problems now include `url`, `solutionUrl`, and `leetcodeUrl`
- confirmed the frontend falls back to a computed GitHub blob URL and a computed LeetCode URL when needed